### PR TITLE
Controller-Settings: Replaced one-time setting of variables by a getter function, consistent to the remaining Legacy Controller Engine API.

### DIFF
--- a/res/controllers/engine-api.d.ts
+++ b/res/controllers/engine-api.d.ts
@@ -25,6 +25,15 @@ declare interface ScriptConnection {
 
 declare namespace engine {
     /**
+     * Gets the value of a controller setting
+     * The value is either set in the preferences dialog,
+     * or got restored from file.
+     * @param name Name of the setting (as specified in the XML file of the mapping)
+     * @returns Value of the setting, or undefined in failure case
+     */
+    function getControllerSetting(name: string): any;
+
+    /**
      * Gets the control value
      *
      * @param group Group of the control e.g. "[Channel1]"

--- a/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp
@@ -103,8 +103,11 @@ void ControllerScriptEngineLegacy::setSettings(
         const QList<std::shared_ptr<AbstractLegacyControllerSetting>>& settings) {
     m_settings.clear();
     for (const auto& pSetting : qAsConst(settings)) {
-        m_settings.append(Setting{
-                pSetting->variableName(), pSetting->value()});
+        QString name = pSetting->variableName();
+        VERIFY_OR_DEBUG_ASSERT(!name.isEmpty()) {
+            continue;
+        }
+        m_settings[name] = pSetting->value();
     }
 }
 
@@ -132,13 +135,6 @@ bool ControllerScriptEngineLegacy::initialize() {
     QJSValue engineGlobalObject = m_pJSEngine->globalObject();
     ControllerScriptInterfaceLegacy* legacyScriptInterface =
             new ControllerScriptInterfaceLegacy(this, m_logger);
-
-    QJSValue settingsObject = m_pJSEngine->newObject();
-    for (const auto& setting : qAsConst(m_settings)) {
-        settingsObject.setProperty(setting.name, setting.value);
-    }
-    engineGlobalObject.setProperty(
-            "controllerSettings", settingsObject);
 
     engineGlobalObject.setProperty(
             "engine", m_pJSEngine->newQObject(legacyScriptInterface));

--- a/src/controllers/scripting/legacy/controllerscriptenginelegacy.h
+++ b/src/controllers/scripting/legacy/controllerscriptenginelegacy.h
@@ -58,7 +58,7 @@ class ControllerScriptEngineLegacy : public ControllerScriptEngineBase {
     QList<QJSValue> m_incomingDataFunctions;
     QHash<QString, QJSValue> m_scriptWrappedFunctionCache;
     QList<LegacyControllerMapping::ScriptFileInfo> m_scriptFiles;
-    QList<Setting> m_settings;
+    QHash<QString, QJSValue> m_settings;
 
     QFileSystemWatcher m_fileWatcher;
 

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
@@ -108,6 +108,29 @@ ControlObjectScript* ControllerScriptInterfaceLegacy::getControlObjectScript(
     return coScript;
 }
 
+QJSValue ControllerScriptInterfaceLegacy::getControllerSetting(const QString& name) {
+    VERIFY_OR_DEBUG_ASSERT(m_pScriptEngineLegacy) {
+        return QJSValue::UndefinedValue;
+    }
+    if (name.isEmpty()) {
+        m_pScriptEngineLegacy->logOrThrowError(
+                QStringLiteral("getControllerSetting called with empty name "
+                               "string, returning undefined")
+                        .arg(name));
+        return QJSValue::UndefinedValue;
+    }
+
+    const auto it = m_pScriptEngineLegacy->m_settings.constFind(name);
+    if (it != m_pScriptEngineLegacy->m_settings.constEnd()) {
+        return it.value();
+    } else {
+        m_pScriptEngineLegacy->logOrThrowError(
+                QStringLiteral("Unknown controllerSetting (%1) returning undefined")
+                        .arg(name));
+        return QJSValue::UndefinedValue;
+    }
+}
+
 double ControllerScriptInterfaceLegacy::getValue(const QString& group, const QString& name) {
     ControlObjectScript* coScript = getControlObjectScript(group, name);
     if (coScript == nullptr) {

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.h
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.h
@@ -22,6 +22,7 @@ class ControllerScriptInterfaceLegacy : public QObject {
 
     virtual ~ControllerScriptInterfaceLegacy();
 
+    Q_INVOKABLE QJSValue getControllerSetting(const QString& name);
     Q_INVOKABLE double getValue(const QString& group, const QString& name);
     Q_INVOKABLE void setValue(const QString& group, const QString& name, double newValue);
     Q_INVOKABLE double getParameter(const QString& group, const QString& name);


### PR DESCRIPTION
@acolombier In this PR I modified the interface to access the contoller settings from the JavaScript-Code. I intended to achieve a unified way to access data acrross the controller engine legacy API. For future features like real time data updates we could add a callback as for the COs.
Hope you like this.