### PR TITLE
don't use sampleOffset in fetchAndDeinterleave() to avoid pops when loops wrap around

### DIFF
--- a/src/engine/bufferscalers/enginebufferscalesignalsmith.cpp
+++ b/src/engine/bufferscalers/enginebufferscalesignalsmith.cpp
@@ -87,7 +87,6 @@ void EngineBufferScaleSignalSmith::clear() {
 }
 
 SINT EngineBufferScaleSignalSmith::fetchAndDeinterleave(SINT sampleToRead, SINT frameOffset) {
-    auto sampleOffset = getOutputSignal().frames2samples(frameOffset);
     auto frameRead = getOutputSignal().samples2frames(
             m_pReadAheadManager->getNextSamples(
                     // The value doesn't matter here. All that matters is we
@@ -102,7 +101,7 @@ SINT EngineBufferScaleSignalSmith::fetchAndDeinterleave(SINT sampleToRead, SINT 
         SampleUtil::deinterleaveBuffer(
                 m_buffers[0].data(frameOffset),
                 m_buffers[1].data(frameOffset),
-                m_interleavedBuffer.data(sampleOffset),
+                m_interleavedBuffer.data(),
                 frameRead);
         break;
     case mixxx::audio::ChannelCount::stem():
@@ -115,7 +114,7 @@ SINT EngineBufferScaleSignalSmith::fetchAndDeinterleave(SINT sampleToRead, SINT 
                 m_buffers[5].data(frameOffset),
                 m_buffers[6].data(frameOffset),
                 m_buffers[7].data(frameOffset),
-                m_interleavedBuffer.data(sampleOffset),
+                m_interleavedBuffer.data(),
                 frameRead);
         break;
     default: {
@@ -134,7 +133,7 @@ SINT EngineBufferScaleSignalSmith::fetchAndDeinterleave(SINT sampleToRead, SINT 
         for (SINT frameIdx = 0; frameIdx < frameRead; ++frameIdx) {
             for (int channel = 0; channel < chCount; channel++) {
                 m_buffers[channel].data(frameOffset)[frameIdx] =
-                        m_interleavedBuffer.data(sampleOffset)[frameIdx * chCount + channel];
+                        m_interleavedBuffer.data()[frameIdx * chCount + channel];
             }
         }
     } break;


### PR DESCRIPTION
This is the first of the issues Gemini noticed and indeed it fixes the pops.
(previously reproducible with loops < 2 beats (@ 80 BPM) with 5 ms buffer and ALSA 44.1 kHz

Gemini said:

### The `fetchAndDeinterleave` Offset Mismatch (The Pop Generator)

This is the primary cause of the pops. When `fetchAndDeinterleave` is called multiple times inside the
`while (frameRead < frameRequired)`
loop in `scaleBuffer`, `frameOffset` becomes greater than 0.

Look at your fetch logic:

```c++
m_pReadAheadManager->getNextSamples(
        ...,
        m_interleavedBuffer.data(), // <-- ALWAYS writes to index 0
        sampleToRead, ...);
```

Regardless of the `frameOffset`, you instruct the `ReadAheadManager` to populate samples starting at index 0 of `m_interleavedBuffer`. However, immediately below in your deinterleaving switches, you read from `m_interleavedBuffer.data(sampleOffset)`:

```c++
SampleUtil::deinterleaveBuffer(
        m_buffers[0].data(frameOffset),
        m_buffers[1].data(frameOffset),
        m_interleavedBuffer.data(sampleOffset), // <-- BUG: Reads past the newly fetched data
        frameRead);
```

When sampleOffset is > 0, you are reading stale or garbage data from the buffer instead of the fresh audio you just fetched, feeding bad data into Signalsmith.

The Fix: Remove sampleOffset when reading from m_interleavedBuffer across all your switch cases in fetchAndDeinterleave.